### PR TITLE
Add missing paren to forward declaration example

### DIFF
--- a/general-and-javascript-style-guides.md
+++ b/general-and-javascript-style-guides.md
@@ -39,7 +39,7 @@ export default Component.extend({
 export default Component.extend({
   actions: {
     authenticate() {
-      this.sendAction(‘authenticate’, this.get(‘email’), this.get(‘password’);
+      this.sendAction(‘authenticate’, this.get(‘email’), this.get(‘password’));
     }
   }
 });


### PR DESCRIPTION
The closing paren is missing from the "bad" example
